### PR TITLE
build: support *BSD ports-provided zeromq bindings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,8 @@
 %% Compile nif using port compiler plugin
 {plugins, [pc,rebar3_hex]}.
 {artifacts, ["priv/erlzmq_nif.so"]}.
-{port_env, [{"CFLAGS", "$CFLAGS -g -Wall -Werror"}, {"LDFLAGS", "$LDFLAGS -lzmq"}]}.
+{port_env, [{"CFLAGS", "$CFLAGS -I/usr/local/include -I./include -g -Wall -Werror"},
+            {"LDFLAGS", "$LDFLAGS -L/usr/local/lib -lzmq"}]}.
 {port_specs, [{ "priv/erlzmq_nif.so", ["c_src/*.c"] }]}.
 
 {provider_hooks,
@@ -20,3 +21,4 @@
 {eunit_opts, [
     verbose
 ]}.
+


### PR DESCRIPTION
thanks for the significant work in brinding dirty nif support @lukaszsamson !

This short PR allows building on FreeBSD (and probably other *BSD systems)
and shouldn't impact Linux builds either.